### PR TITLE
Use np.asarray() to support numpy 2.0

### DIFF
--- a/daisy/utils/metrics.py
+++ b/daisy/utils/metrics.py
@@ -203,7 +203,7 @@ def MAP(test_ur, pred_ur, test_u):
 
 def NDCG(test_ur, pred_ur, test_u):
     def DCG(r):
-        r = np.asfarray(r) != 0
+        r = np.asarray(r, dtype="float") != 0
         if r.size:
             dcg = np.sum(np.subtract(np.power(2, r), 1) / np.log2(np.arange(2, r.size + 2)))
             return dcg


### PR DESCRIPTION
Since NumPy 2.0 removed np.asfarray function, it should be np.asarray instead. Otherwise, it causes AttributeError like:

```py
AttributeError: `np.asfarray` was removed in the NumPy 2.0 release. Use `np.asarray` with a proper dtype instead.. Did you mean: 'asarray'?
```